### PR TITLE
Version Bump for multiple packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,24 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "lorisleiva/laravel-actions": "^2.9",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "illuminate/contracts": "^12.0|^13.0",
+        "lorisleiva/laravel-actions": "^2.10",
+        "spatie/laravel-package-tools": "^1.93"
     },
     "require-dev": {
         "hyperlinkgroup/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.5",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "larastan/larastan": "^3.0",
+        "laravel/pao": "^1.1",
+        "nunomaduro/collision": "^8.9.3",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^4.4.3",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -64,7 +65,6 @@
         ],
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint",
         "serve": [
             "Composer\\Config::disableProcessTimeout",
@@ -77,6 +77,9 @@
         ]
     },
     "config": {
+        "platform": {
+            "php": "8.3"
+        },
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
@@ -93,6 +96,6 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
     level: 5
     paths:
         - src
-        - config
         - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
 	backupGlobals="false"
 	bootstrap="vendor/autoload.php"
 	colors="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11/phpunit.xsd"
 	backupGlobals="false"
 	bootstrap="vendor/autoload.php"
 	colors="true"
@@ -20,13 +20,6 @@
 			<directory>tests</directory>
 		</testsuite>
 	</testsuites>
-	<coverage>
-		<report>
-			<html outputDirectory="build/coverage"/>
-			<text outputFile="build/coverage.txt"/>
-			<clover outputFile="build/logs/clover.xml"/>
-		</report>
-	</coverage>
 	<logging>
 		<junit outputFile="build/report.junit.xml"/>
 	</logging>

--- a/src/Actions/CollectLocalTranslations.php
+++ b/src/Actions/CollectLocalTranslations.php
@@ -133,7 +133,7 @@ final class CollectLocalTranslations
 	{
 		$primary = lang_path();
 
-		if (is_string($primary) && $primary !== '' && File::isDirectory($primary)) {
+		if (filled($primary) && File::isDirectory($primary)) {
 			return [$primary];
 		}
 
@@ -167,7 +167,7 @@ final class CollectLocalTranslations
 				$filenameWithoutExtension = $file->getFilenameWithoutExtension();
 				$isLinguistFile = strtolower($file->getFilename()) === self::LINGUIST_FILENAME;
 				$pathSegments = explode(DIRECTORY_SEPARATOR, $relativePath);
-				$topLevelSegment = $pathSegments[0] ?? '';
+				$topLevelSegment = $pathSegments[0];
 
 				$language = $isLinguistFile
 					? basename($file->getPath())

--- a/src/Linguist.php
+++ b/src/Linguist.php
@@ -117,7 +117,7 @@ class Linguist
 
 		$this->getAllLanguages();
 
-		return $this->languages ?? collect();
+		return $this->languages;
 	}
 
 	public function setLanguages(Collection $languages): self

--- a/src/Services/SetupOrchestrator.php
+++ b/src/Services/SetupOrchestrator.php
@@ -80,7 +80,7 @@ final class SetupOrchestrator
 			);
 
 			// Step 6: Trigger auto-translation if requested
-			if ($input->triggerAutoTranslate && ($syncResult?->overallSuccess ?? false)) {
+			if ($input->triggerAutoTranslate && $syncResult !== null && $syncResult->overallSuccess) {
 				$autoTranslate = $this->triggerAutoTranslate(
 					runtimeClient: $linguistApiClient,
 				);


### PR DESCRIPTION
This Pull request bumps the minimum PHP version to 8.3 and supported Laravel Version to 13. 
It also drops support for old Laravel 10 and 11 versions.

## Updates in detail
- Updates minimum PHP version from `8.1` to `8.3`:
- Laravel support: `10/11/12` → `12/13`
- PHPUnit schema: `10.3` → `11`
- Pest: `2.x` → `4.x`
- Larastan: `2.x` → `3.x`
- PHPStan packages: `1.x` → `2.x`
- Orchestra Testbench: `8.x` → `10/11`
- Add Laravel Pao package to reduce token usage for Agent sessions
- When updating the packages I noticed, that the `minimum-stability` was set to `dev`. So I changed that to `stable`.
- I added a platform config for PHP 8.3 top prevent `composer update` from picking the wrong version
- Removes test-coverage script and coverage configuration from `phpunit.xml` as it was never used for this package 